### PR TITLE
Solve shared attributes between worker and pipeline

### DIFF
--- a/src/pipeline/base_pipeline.py
+++ b/src/pipeline/base_pipeline.py
@@ -41,12 +41,6 @@ class BasePipeline(ABC):
         if args.pretrained is not None:
             self._load_pretrained(args.pretrained)
 
-        self._worker_shared_list = {
-            'common': ['config', 'device', 'model', 'loss_functions',
-                       'evaluation_metrics', 'writer'],
-            'trainer': ['optimizer'], 'tester': [], 'validator': []
-        }
-
     @abstractmethod
     def _setup_config(self):
         pass

--- a/src/pipeline/testing_pipeline.py
+++ b/src/pipeline/testing_pipeline.py
@@ -26,10 +26,6 @@ class TestingPipeline(BasePipeline):
         pass
 
     def _create_workers(self):
-        shared_list = (self._worker_shared_list['common'] + self._worker_shared_list['tester'])
-        tester = Tester(
-            {attr_name: getattr(self, attr_name) for attr_name in shared_list},
-            self.data_loader, 0
-        )
+        tester = Tester(self, self.data_loader, 0)
         workers = [tester]
         return workers

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -41,21 +41,15 @@ class TrainingPipeline(BasePipeline):
         self.do_validation = len(self.valid_data_loaders) > 0
 
     def _create_workers(self):
-        trainer_shared_list = (self._worker_shared_list['common']
-                               + self._worker_shared_list['trainer'])
-        valid_shared_list = (self._worker_shared_list['common']
-                             + self._worker_shared_list['validator'])
         trainer = Trainer(
-            {attr_name: getattr(self, attr_name) for attr_name in trainer_shared_list},
-            self.data_loader, self.train_iteration_count
+            self, self.data_loader, self.train_iteration_count
         )
         workers = [trainer]
 
         for i, valid_data_loader in enumerate(self.valid_data_loaders):
             workers.append(
                 Validator(
-                    {attr_name: getattr(self, attr_name) for attr_name in valid_shared_list},
-                    valid_data_loader, self.valid_iteration_counts[i]
+                    self, valid_data_loader, self.valid_iteration_counts[i]
                 )
             )
         return workers

--- a/src/worker/trainer.py
+++ b/src/worker/trainer.py
@@ -5,6 +5,7 @@ import numpy as np
 from .worker_template import WorkerTemplate
 from utils.logging_config import logger
 from utils.util import get_lr
+from pipeline.base_pipeline import BasePipeline
 
 
 class Trainer(WorkerTemplate):
@@ -14,6 +15,12 @@ class Trainer(WorkerTemplate):
     Note:
         Inherited from WorkerTemplate.
     """
+    def __init__(self, pipeline: BasePipeline, *args):
+        super().__init__(pipeline, *args)
+        # Some shared attributes are trainer exclusive and therefore is initialized here
+        for attr_name in ['optimizer']:
+            setattr(self, attr_name, getattr(pipeline, attr_name))
+
     def _print_log(self, epoch, batch_idx, batch_start_time, loss, metrics):
         logger.info(
             f'Epoch: {epoch} [{batch_idx * self.data_loader.batch_size}/{self.data_loader.n_samples} '

--- a/src/worker/worker_template.py
+++ b/src/worker/worker_template.py
@@ -6,6 +6,7 @@ import torch
 from torchvision.utils import make_grid
 
 from data_loader.base_data_loader import BaseDataLoader
+from pipeline.base_pipeline import BasePipeline
 
 
 class WorkerTemplate(ABC):
@@ -15,10 +16,11 @@ class WorkerTemplate(ABC):
     that deals with the main optimization & model inference.
     """
     def __init__(
-        self, attributes: dict, data_loader: BaseDataLoader, step: int
+        self, pipeline: BasePipeline, data_loader: BaseDataLoader, step: int
     ):
-        for name, value in attributes.items():
-            setattr(self, name, value)
+        # Attributes listed below are shared from pipeline among all different workers.
+        for attr_name in ['config', 'device', 'model', 'loss_functions', 'evaluation_metrics', 'writer']:
+            setattr(self, attr_name, getattr(pipeline, attr_name))
 
         self.log_step = self.config['trainer']['log_step']
         self.verbosity = self.config['trainer']['verbosity']


### PR DESCRIPTION
## Why do we need this PR?
* Passing the shared attributes through worker constructor explicitly makes it hard to maintain.

## How is it implemented?
* Use `_worker_shared_list` to specify what to share and pass the attributes as a dictionary.

#### PR readiness checklist
> - [ v ] Did it pass the Flake8 check?
> - [ v ] Did you test this PR?  
