### PR TITLE
Gan validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/pytorch_fid"]
+	path = libs/pytorch_fid
+	url = https://github.com/Nash2325138/pytorch-fid.git

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -93,7 +93,7 @@
     },
     "metrics": {
         "fid_score": {
-            "type": "FIDScoreOnline",
+            "type": "FIDScoreInceptionV3",
             "args": {
                 "output_key": "G_z",
                 "target_key": "data_input",

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -39,7 +39,7 @@
     "trainer": {
         "epochs": 50,
         "save_dir": "saved/",
-        "save_freq": 10,
+        "save_freq": 5,
         "monitor_mode": "min",
         "monitored_loader": "valid_mnist",
         "monitored_metric": "avg_fid_score"
@@ -92,8 +92,16 @@
         }
     },
     "metrics": {
+        "fid_score": {
+            "type": "FIDScoreOnline",
+            "args": {
+                "output_key": "G_z",
+                "target_key": "data_input",
+                "nickname": "fid_score"
+            }
+        }
     },
     "log_step": 100,
     "verbosity": 2,
-    "name": "GAN_template_train_config_SN"
+    "name": "GAN_template_train_config"
 }

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -3,6 +3,7 @@
     "optimizers": {
         "generator": {
             "target_network": "generator",
+            "forward_scenario": "generator",
             "type": "Adam",
             "args": {
                 "lr": 0.0002,
@@ -11,6 +12,7 @@
         },
         "discriminator": {
             "target_network": "discriminator",
+            "forward_scenario": "discriminator",
             "type": "Adam",
             "args": {
                 "lr": 0.0002,

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -39,10 +39,10 @@
     "trainer": {
         "epochs": 50,
         "save_dir": "saved/",
-        "save_freq": 1,
+        "save_freq": 10,
         "monitor_mode": "min",
         "monitored_loader": "valid_mnist",
-        "monitored_metric": "avg_loss"
+        "monitored_metric": "avg_fid_score"
     },
     "trainer_args": {},
     "visualization": {
@@ -52,7 +52,7 @@
     "arch": {
         "type": "MnistGAN",
         "args": {
-            "spectral_normalization": false
+            "spectral_normalization": true
         }
     },
     "optimize_strategy": "GAN",
@@ -61,7 +61,7 @@
         "args": {
             "data_dir": "../datasets/mnist",
             "batch_size": 128,
-            "validation_split": 0.0,
+            "validation_split": 0.2,
             "num_workers": 4,
             "img_size": 64,
             "name": "mnist",
@@ -92,16 +92,8 @@
         }
     },
     "metrics": {
-        "fid_score": {
-            "type": "FIDScoreOffline",
-            "args": {
-                "output_key": "G_z",
-                "target_key": "data_input",
-                "nickname": "fid_score"
-            }
-        }
     },
-    "log_step": 200,
+    "log_step": 100,
     "verbosity": 2,
-    "name": "GAN_template_train_config"
+    "name": "GAN_template_train_config_SN"
 }

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -92,6 +92,14 @@
         }
     },
     "metrics": {
+        "fid_score": {
+            "type": "FIDScore",
+            "args": {
+                "output_key": "G_z",
+                "target_key": "data_input",
+                "nickname": "fid_score"
+            }
+        }
     },
     "log_step": 200,
     "verbosity": 2,

--- a/src/configs/template_GAN_train_config.json
+++ b/src/configs/template_GAN_train_config.json
@@ -93,7 +93,7 @@
     },
     "metrics": {
         "fid_score": {
-            "type": "FIDScore",
+            "type": "FIDScoreOffline",
             "args": {
                 "output_key": "G_z",
                 "target_key": "data_input",

--- a/src/model/loss.py
+++ b/src/model/loss.py
@@ -38,23 +38,27 @@ class GANLoss(BaseLoss):
         *args, **kargs
     ):
         super().__init__(output_key=None, target_key=None, *args, **kargs)
+        assert network in ['generator', 'discriminator']
         if type_ == 'nsgan':
             self.loss_fn = nn.BCELoss()
-
         elif type_ == 'lsgan':
             self.loss_fn = nn.MSELoss()
-
         elif type_ == 'l1':
             self.loss_fn = nn.L1Loss()
-
+        elif type_ == 'hinge':
+            self.hinge_loss = HingeLossG() if network == 'generator' else HingeLossD()
         else:
             raise NotImplementedError()
+        self.type_ = type_
 
         self.network = network
         self.register_buffer('real_label', torch.tensor(target_real_label))
         self.register_buffer('fake_label', torch.tensor(target_fake_label))
 
     def forward(self, data_dict, output_dict):
+        if self.type_ == 'hinge':
+            return self.hinge_loss(data_dict, output_dict)
+
         if self.network == 'generator':
             outputs = output_dict['D_G_z']
             targets = self.real_label.expand_as(outputs).to(outputs.device)
@@ -78,10 +82,8 @@ class GANLoss(BaseLoss):
 
 # Formulation reference: https://arxiv.org/pdf/1802.05957.pdf (eq. 17)
 class HingeLossG(nn.Module):
-    def __init__(self, nickname=None, weight=1):
+    def __init__(self):
         super().__init__()
-        self.weight = weight
-        self.nickname = self.__class__.__name__ if nickname is None else nickname
 
     def forward(self, data_dict, output_dict):
         D_G_z = output_dict['D_G_z']
@@ -90,10 +92,8 @@ class HingeLossG(nn.Module):
 
 # Formulation reference: https://arxiv.org/pdf/1802.05957.pdf (eq. 16)
 class HingeLossD(nn.Module):
-    def __init__(self, nickname=None, weight=1):
+    def __init__(self):
         super().__init__()
-        self.weight = weight
-        self.nickname = self.__class__.__name__ if nickname is None else nickname
         self.relu = nn.ReLU()
 
     def forward(self, data_dict, output_dict):

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 from torchvision import transforms
 
-from utils.util import UnNormalize, lib_path, import_given_path
+from utils.util import InverseNormalize, lib_path, import_given_path
 
 inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
 fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
@@ -67,7 +67,7 @@ class FIDScoreOffline(BaseMetric):
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
         self.from_tensor_to_pil = transforms.Compose([
-            UnNormalize(unnorm_mean, unnorm_mean),
+            InverseNormalize(unnorm_mean, unnorm_mean),
             transforms.ToPILImage()
         ])
         self.tmp_gt_dir = tempfile.TemporaryDirectory(prefix='gt_')
@@ -105,7 +105,7 @@ class FIDScoreOnline(BaseMetric):
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
-        self._unNormalizer = UnNormalize(unnorm_mean, unnorm_mean)
+        self._unNormalizer = InverseNormalize(unnorm_mean, unnorm_mean)
         block_idx = inception.InceptionV3.BLOCK_INDEX_BY_DIM[2048]
         self.inception_model = inception.InceptionV3([block_idx])
         self.inception_model.eval()

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 from torchvision import transforms
 
-from utils.util import InverseNormalize, lib_path, import_given_path
+from utils.util import DeNormalize, lib_path, import_given_path
 
 inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
 fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
@@ -67,7 +67,7 @@ class FIDScoreOffline(BaseMetric):
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
         self.from_tensor_to_pil = transforms.Compose([
-            InverseNormalize(unnorm_mean, unnorm_mean),
+            DeNormalize(unnorm_mean, unnorm_mean),
             transforms.ToPILImage()
         ])
         self.tmp_gt_dir = tempfile.TemporaryDirectory(prefix='gt_')
@@ -105,7 +105,7 @@ class FIDScore(BaseMetric):
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
-        self._unNormalizer = InverseNormalize(unnorm_mean, unnorm_mean)
+        self._deNormalizer = DeNormalize(unnorm_mean, unnorm_mean)
         self._gt_activations = []
         self._out_activations = []
 
@@ -114,7 +114,7 @@ class FIDScore(BaseMetric):
         self._out_activations = []
 
     def _preprocess_tensor(self, tensor):
-        tensor = self._unNormalizer(tensor)  # domain: [-1, 1] -> [0, 1]
+        tensor = self._deNormalizer(tensor)  # domain: [-1, 1] -> [0, 1]
         tensor = tensor.repeat(1, 3, 1, 1)   # convert 1-channel images to 3-channels
         return tensor
 

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -1,5 +1,6 @@
 import torch
 from abc import abstractmethod
+from utils.util import UnNormalize
 
 
 class BaseMetric(torch.nn.Module):
@@ -47,3 +48,25 @@ class TopKAcc(BaseMetric):
 
     def finalize(self):
         return self.total_correct / self.total_number
+
+
+class FIDScore(torch.nn.Module):
+    def __init__(self, k, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname=None):
+        super().__init__()
+        self.k = k
+        self.nickname = f'FID_InceptionV3' if nickname is None else nickname
+        self.output_key = output_key
+        self.target_key = target_key
+        self.unnormalizer = UnNormalize(unnorm_mean, unnorm_mean)
+
+    def clear(self):
+        # TODO: create temporary files using TemporaryDirectory, etc. in package tempfile
+        pass
+
+    def update(self, data, output):
+        # TODO: unnormalize real and fake images, save them to temporary files.
+        pass
+
+    def finalize(self):
+        # TODO: calculate fid scores using functions in libs/pytorch_fid/fid_score.py
+        pass

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -2,6 +2,9 @@ import os
 import torch
 from abc import abstractmethod
 import importlib.util
+import tempfile
+
+from torchvision import transforms
 
 from utils.util import UnNormalize, lib_path
 
@@ -53,26 +56,48 @@ class TopKAcc(BaseMetric):
         return self.total_correct / self.total_number
 
 
-class FIDScore(torch.nn.Module):
-    spec = importlib.util.spec_from_file_location("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
-    fid_score = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(fid_score)
+class FIDScoreOffline(torch.nn.Module):
+    """
+    Module calculating FID score
+    """
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__()
         self.nickname = nickname
         self.output_key = output_key
         self.target_key = target_key
-        self.unnormalizer = UnNormalize(unnorm_mean, unnorm_mean)
+        self.from_tensor_to_pil = transforms.Compose([
+            UnNormalize(unnorm_mean, unnorm_mean),
+            transforms.ToPILImage()
+        ])
+        self.tmp_gt_dir = tempfile.TemporaryDirectory(prefix='gt_')
+        self.tmp_out_dir = tempfile.TemporaryDirectory(prefix='out_')
+
+        # Load module fid_score given path
+        spec = importlib.util.spec_from_file_location("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
+        self.fid_score = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.fid_score)
 
     def clear(self):
-        # TODO: create containers of temporary files using TemporaryDirectory, etc. in package tempfile
-        pass
+        self.tmp_gt_dir.cleanup()
+        self.tmp_out_dir.cleanup()
+        self.tmp_gt_dir = tempfile.TemporaryDirectory(prefix='gt_')
+        self.tmp_out_dir = tempfile.TemporaryDirectory(prefix='out_')
+
+    def _save_img_tensor(self, tensor, buffer_dir):
+        """ Save image tensor to a named temporary file and return the name."""
+        temp_f = tempfile.NamedTemporaryFile(suffix='.png', dir=buffer_dir.name, delete=False)
+        pil_image = self.from_tensor_to_pil(tensor.cpu())
+        pil_image.save(temp_f)
+        temp_f.close()
 
     def update(self, data, output):
-        # TODO: unnormalize real and fake images, save them to temporary files.
+        for gt_tensor, out_tensor in zip(data[self.target_key], output[self.output_key]):
+            self._save_img_tensor(gt_tensor, self.tmp_gt_dir)
+            self._save_img_tensor(out_tensor.clamp(-1, 1), self.tmp_out_dir)
         return None
 
     def finalize(self):
         # TODO: calculate fid scores using functions in libs/pytorch_fid/fid_score.py
+        self.fid_score.calculate_fid_given_paths()
         return 0

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -56,16 +56,13 @@ class TopKAcc(BaseMetric):
         return self.total_correct / self.total_number
 
 
-class FIDScoreOffline(torch.nn.Module):
+class FIDScoreOffline(BaseMetric):
     """
     Module calculating FID score
     """
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
-        super().__init__()
-        self.nickname = nickname
-        self.output_key = output_key
-        self.target_key = target_key
+        super().__init__(output_key, target_key, nickname)
         self.from_tensor_to_pil = transforms.Compose([
             UnNormalize(unnorm_mean, unnorm_mean),
             transforms.ToPILImage()
@@ -98,7 +95,6 @@ class FIDScoreOffline(torch.nn.Module):
         return None
 
     def finalize(self):
-        # TODO: calculate fid scores using functions in libs/pytorch_fid/fid_score.py
         fid_score = self.fid_score.calculate_fid_given_paths(
             paths=[self.tmp_gt_dir.name, self.tmp_out_dir.name],
             batch_size=10, cuda=True, dims=2048)

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -1,6 +1,9 @@
+import os
 import torch
 from abc import abstractmethod
-from utils.util import UnNormalize
+import importlib.util
+
+from utils.util import UnNormalize, lib_path
 
 
 class BaseMetric(torch.nn.Module):
@@ -51,22 +54,25 @@ class TopKAcc(BaseMetric):
 
 
 class FIDScore(torch.nn.Module):
-    def __init__(self, k, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname=None):
+    spec = importlib.util.spec_from_file_location("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
+    fid_score = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fid_score)
+
+    def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__()
-        self.k = k
-        self.nickname = f'FID_InceptionV3' if nickname is None else nickname
+        self.nickname = nickname
         self.output_key = output_key
         self.target_key = target_key
         self.unnormalizer = UnNormalize(unnorm_mean, unnorm_mean)
 
     def clear(self):
-        # TODO: create temporary files using TemporaryDirectory, etc. in package tempfile
+        # TODO: create containers of temporary files using TemporaryDirectory, etc. in package tempfile
         pass
 
     def update(self, data, output):
         # TODO: unnormalize real and fake images, save them to temporary files.
-        pass
+        return None
 
     def finalize(self):
         # TODO: calculate fid scores using functions in libs/pytorch_fid/fid_score.py
-        pass
+        return 0

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -108,6 +108,7 @@ class FIDScoreOnline(BaseMetric):
         self._unNormalizer = UnNormalize(unnorm_mean, unnorm_mean)
         block_idx = inception.InceptionV3.BLOCK_INDEX_BY_DIM[2048]
         self.inception_model = inception.InceptionV3([block_idx])
+        self.inception_model.eval()
         self._gt_activations = []
         self._out_activations = []
 
@@ -126,7 +127,7 @@ class FIDScoreOnline(BaseMetric):
     def update(self, data, output):
         with torch.no_grad():
             gt_tensors = self._preprocess_tensor(data[self.target_key])
-            out_tensors = self._preprocess_tensor(output[self.output_key].clamp(-1, 1))
+            out_tensors = self._preprocess_tensor(output[self.output_key])
             self._gt_activations.append(self._get_activation(gt_tensors))
             self._out_activations.append(self._get_activation(out_tensors))
         return None

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -99,5 +99,7 @@ class FIDScoreOffline(torch.nn.Module):
 
     def finalize(self):
         # TODO: calculate fid scores using functions in libs/pytorch_fid/fid_score.py
-        self.fid_score.calculate_fid_given_paths()
-        return 0
+        fid_score = self.fid_score.calculate_fid_given_paths(
+            paths=[self.tmp_gt_dir.name, self.tmp_out_dir.name],
+            batch_size=10, cuda=True, dims=2048)
+        return fid_score

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -36,7 +36,8 @@ class TrainingPipeline(BasePipeline):
         ]
 
     def _setup_gan_loss_functions(self):
-        """ Setup GAN loss functions. Will only be called when self.optimize_strategy == 'GAN' """
+        """ Setup GAN loss functions. Will only be called when self.optimize_strategy == 'GAN'
+        The keys of gan_losses in config should have strict one-to-one mapping with names of optimizers. """
         self.gan_loss_functions = {
             key: getattr(module_loss, entry['type'])(**entry['args']).to(self.device)
             for key, entry in global_config['gan_losses'].items()

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -1,7 +1,10 @@
 import os
+import os.path as op
 from glob import glob
 
 import torch
+
+lib_path = op.abspath(op.join(__file__, op.pardir, op.pardir, op.pardir, 'libs'))
 
 
 def get_instance(module, name, config, *args, **kargs):

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -1,6 +1,7 @@
 import os
 import os.path as op
 from glob import glob
+import importlib.util
 
 import torch
 
@@ -63,3 +64,10 @@ class UnNormalize(object):
             t.mul_(s).add_(m)
             # The normalize code -> t.sub_(m).div_(s)
         return tensor
+
+
+def import_given_path(module_name, path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -42,3 +42,21 @@ def one_hot_embedding(labels, num_classes):
     """
     y = torch.eye(num_classes)
     return y[labels]
+
+
+class UnNormalize(object):
+    def __init__(self, mean, std):
+        self.mean = mean
+        self.std = std
+
+    def __call__(self, tensor):
+        """
+        Args:
+            tensor (Tensor): Tensor image of size (B, C, H, W) to be normalized.
+        Returns:
+            Tensor: Normalized image.
+        """
+        for t, m, s in zip(tensor, self.mean, self.std):
+            t.mul_(s).add_(m)
+            # The normalize code -> t.sub_(m).div_(s)
+        return tensor

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -49,7 +49,7 @@ def one_hot_embedding(labels, num_classes):
     return y[labels]
 
 
-class UnNormalize(object):
+class InverseNormalize(object):
     def __init__(self, mean, std):
         self.mean = mean
         self.std = std

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -49,7 +49,7 @@ def one_hot_embedding(labels, num_classes):
     return y[labels]
 
 
-class InverseNormalize(object):
+class DeNormalize(object):
     def __init__(self, mean, std):
         self.mean = mean
         self.std = std

--- a/src/worker/trainer.py
+++ b/src/worker/trainer.py
@@ -53,13 +53,13 @@ class Trainer(TrainingWorker):
             total_loss = 0
             for optimizer_name in self.optimizers.keys():
                 self.optimizers[optimizer_name].zero_grad()
-                network_name = global_config['optimizers'][optimizer_name]['target_network']
-                model_output = self.model(data, network_name)
-                loss = self._get_and_write_gan_loss(data, model_output, network_name)
+                forward_scenario = global_config['optimizers'][optimizer_name]['forward_scenario']
+                model_output = self.model(data, forward_scenario)
+                loss = self._get_and_write_gan_loss(data, model_output, optimizer_name)
                 loss.backward()
                 total_loss += loss
 
-                self.optimizers[network_name].step()
+                self.optimizers[optimizer_name].step()
 
         return model_output, total_loss
 

--- a/src/worker/training_worker.py
+++ b/src/worker/training_worker.py
@@ -45,10 +45,10 @@ class TrainingWorker(WorkerTemplate):
 
         return {'log': log}
 
-    def _get_and_write_gan_loss(self, data, model_output, network_name):
+    def _get_and_write_gan_loss(self, data, model_output, optimize_name):
         """ Calculate GAN loss and write them to Tensorboard
         """
-        loss_function = self.gan_loss_functions[network_name]
+        loss_function = self.gan_loss_functions[optimize_name]
         loss = loss_function(data, model_output) * loss_function.weight
         self.writer.add_scalar(f'{loss_function.nickname}', loss.item())
         return loss

--- a/src/worker/validator.py
+++ b/src/worker/validator.py
@@ -26,13 +26,9 @@ class Validator(TrainingWorker):
         if self.optimize_strategy == 'normal':
             model_output = self.model(data)
             losses, total_loss = self._get_and_write_losses(data, model_output)
-
         elif self.optimize_strategy == 'GAN':
-            total_loss = 0
-            for network_name in self.model.network_names:
-                model_output = self.model(data, network_name)
-                loss = self._get_and_write_gan_loss(data, model_output, network_name)
-                total_loss += loss
+            model_output = self.model(data, scenario='generator_only')
+            losses, total_loss = self._get_and_write_losses(data, model_output)
 
         return model_output, total_loss
 

--- a/src/worker/worker_template.py
+++ b/src/worker/worker_template.py
@@ -91,7 +91,10 @@ class WorkerTemplate(ABC):
             loss = loss_function(data, model_output) * loss_function.weight
             losses[loss_function.nickname] = loss
             self.writer.add_scalar(f'{loss_function.nickname}', loss.item())
-        total_loss = torch.stack(list(losses.values()), dim=0).sum(dim=0)
+        if len(self.loss_functions) == 0:
+            total_loss = torch.zeros([1])
+        else:
+            total_loss = torch.stack(list(losses.values()), dim=0).sum(dim=0)
         self.writer.add_scalar('total_loss', total_loss.item())
         return losses, total_loss
 

--- a/src/worker/worker_template.py
+++ b/src/worker/worker_template.py
@@ -74,6 +74,8 @@ class WorkerTemplate(ABC):
         self.writer.add_image("data_input", make_grid(data["data_input"], nrow=4, normalize=True))
         if self.optimize_strategy == 'GAN':
             self.writer.add_image("G_z", make_grid(model_output["G_z"], nrow=4, normalize=True))
+            self.writer.add_histogram("dist_G_z", model_output["G_z"])
+            self.writer.add_histogram("dist_x", data["data_input"])
 
     def _setup_writer(self):
         """ Setup Tensorboard writer for each iteration """


### PR DESCRIPTION
## Why do we need this PR?
* Add FID score to evaluate GAN training
![image](https://user-images.githubusercontent.com/17662095/63152436-6bc3a500-c03e-11e9-9639-09e92a456920.png)

## How is it implemented?
* Add metric class `FIDScoreOnline` and `FIDScoreOffline` utilizing submodule `fid_score`
  * The output numbers will have slightly difference (<1%) derived from missing precision of saved images (0\~1 float -> 0\~255 integer)
  * `FIDScoreOnline` is recommended to use

## Other Changes
* Add `forward_scenario`
* Update GAN training config: turn on spectral norm and change monitored metric to fid score
* Tensorboard: plot distribution of `x` and `G(x)`
* Disable GAN related losses calcualteion on the validation set. 

#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
