### PR TITLE
Change valid_data_loaders in testing pipeline to test_data_loaders

### DIFF
--- a/src/configs/template_test_config.json
+++ b/src/configs/template_test_config.json
@@ -1,20 +1,5 @@
 {
     "n_gpu": 1,
-    "optimizer": {
-        "type": "Adam",
-        "args": {
-            "lr": 0.0001,
-            "weight_decay": 0,
-            "amsgrad": true
-        }
-    },
-    "lr_scheduler": {
-        "type": "StepLR",
-        "args": {
-            "step_size": 5,
-            "gamma": 0.6
-        }
-    },
     "trainer": {
         "epochs": 100,
         "save_dir": "saved/",
@@ -43,7 +28,7 @@
             "name": "mnist"
         }
     },
-    "valid_data_loaders": {
+    "test_data_loaders": {
         "0": {
             "type": "MnistDataLoader",
             "args": {

--- a/src/pipeline/base_pipeline.py
+++ b/src/pipeline/base_pipeline.py
@@ -30,8 +30,9 @@ class BasePipeline(ABC):
         self._print_config_messages()
 
         self.device, self.device_ids = self._setup_device()
-        self._setup_data_loader()
-        self._setup_valid_data_loaders()
+        self.data_loader = self._setup_data_loader()
+        self.valid_data_loaders = self._setup_valid_data_loaders()
+        self.test_data_loaders = self._setup_test_data_loaders()
 
         self.optimize_strategy = global_config.get('optimize_strategy', 'normal')
         self._setup_model()
@@ -123,7 +124,7 @@ class BasePipeline(ABC):
         return model
 
     def _setup_data_loader(self, key='data_loader'):
-        self.data_loader = get_instance(module_data, key, global_config)
+        return get_instance(module_data, key, global_config)
 
     def _setup_data_loaders(self, key):
         data_loaders = [
@@ -134,14 +135,18 @@ class BasePipeline(ABC):
 
     def _setup_valid_data_loaders(self):
         if 'valid_data_loaders' in global_config.keys():
-            self.valid_data_loaders = self._setup_data_loaders('valid_data_loaders')
+            valid_data_loaders = self._setup_data_loaders('valid_data_loaders')
 
             if self.data_loader.validation_split > 0:
                 raise ValueError(f'Split ratio should not > 0 when other validation loaders are specified.')
         elif self.data_loader.validation_split > 0:
-            self.valid_data_loaders = [self.data_loader.split_validation()]
+            valid_data_loaders = [self.data_loader.split_validation()]
         else:
-            self.valid_data_loaders = []
+            valid_data_loaders = []
+        return valid_data_loaders
+
+    def _setup_test_data_loaders(self):
+        return None
 
     def _setup_evaluation_metrics(self):
         evaluation_metrics = [

--- a/src/pipeline/testing_pipeline.py
+++ b/src/pipeline/testing_pipeline.py
@@ -43,8 +43,8 @@ class TestingPipeline(BasePipeline):
     def _create_workers(self):
         workers = []
         # Add a tester for each data loader
-        for valid_data_loader in self.valid_data_loaders:
-            tester = Tester(self, valid_data_loader, 0)
+        for test_data_loader in self.test_data_loaders:
+            tester = Tester(self, test_data_loader, 0)
             workers += [tester]
         return workers
 
@@ -52,6 +52,13 @@ class TestingPipeline(BasePipeline):
         path = os.path.join(self.saving_dir, f'{name}_output.npz')
         logger.info(f'Saving {path}...')
         np.savez(path, **worker_output)
+
+    def _setup_test_data_loaders(self):
+        if 'test_data_loaders' in global_config.keys():
+            test_data_loaders = self._setup_data_loaders('test_data_loaders')
+            return test_data_loaders
+        else:
+            raise ValueError(f"No test_data_loaders key in config")
 
     def run(self):
         """


### PR DESCRIPTION
## Why do we need this PR?
* Testing data is using valid_data_loaders, which does not make sense

## How is it implemented?
* Add test_data_loader to base_pipeline, with default value as an empty list
* Change valid_data_loaders in the testing pipeline to test_data_loaders
* Fix optimizers in testing_pipeline


#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
