### PR TITLE
Add save_while_infer option to avoid storing too many results in memory

### DIFF
--- a/src/configs/template_test_config.json
+++ b/src/configs/template_test_config.json
@@ -18,16 +18,6 @@
         "type": "MnistModel",
         "args": {}
     },
-    "data_loader": {
-        "type": "MnistDataLoader",
-        "args": {
-            "data_dir": "../datasets/mnist",
-            "batch_size": 32,
-            "validation_split": 0,
-            "num_workers": 4,
-            "name": "mnist"
-        }
-    },
     "test_data_loaders": {
         "0": {
             "type": "MnistDataLoader",

--- a/src/configs/template_test_config.json
+++ b/src/configs/template_test_config.json
@@ -73,6 +73,7 @@
     },
     "log_step": 500,
     "verbosity": 2,
-    "saved_keys": ["data_input", "data_target", "model_output"],
+    "saved_keys": ["data_input", "data_target", "model_output", "index"],
+    "save_while_infer": true,
     "name": "template_test_config"
 }

--- a/src/data_loader/mnist.py
+++ b/src/data_loader/mnist.py
@@ -12,6 +12,7 @@ class MnistDataset(datasets.MNIST):
         """ Overwrite __getitem__ to return dictionary """
         data = super().__getitem__(index)
         return {
+            "index": index,
             "data_input": data[0],
             "data_target": data[1]
         }

--- a/src/data_loader/mnist_result.py
+++ b/src/data_loader/mnist_result.py
@@ -17,6 +17,7 @@ class MnistResultDataset(Dataset):
         """ Overwrite __getitem__ to return dictionary """
         result = self.results[index]
         return {
+            "index": index,
             self.key: result
         }
 

--- a/src/pipeline/testing_pipeline.py
+++ b/src/pipeline/testing_pipeline.py
@@ -24,7 +24,7 @@ class TestingPipeline(BasePipeline):
         if os.path.exists(saving_dir):
             logger.warning(f'The saving directory "{saving_dir}" already exists. '
                            f'If continued, some files might be overwriten.')
-            response = input('Proceed? [y/N]')
+            response = input('Proceed? [y/N] ')
             if response != 'y':
                 logger.info('Exit.')
                 exit()
@@ -56,7 +56,7 @@ class TestingPipeline(BasePipeline):
 
     def _save_inference_results(self, name: str, worker_output: dict):
         path = os.path.join(self.saving_dir, f'{name}_output.npz')
-        logger.info(f'Saving {path}...')
+        logger.info(f'Saving {path} ...')
         np.savez(path, **worker_output)
 
     def _setup_test_data_loaders(self):

--- a/src/pipeline/testing_pipeline.py
+++ b/src/pipeline/testing_pipeline.py
@@ -37,6 +37,12 @@ class TestingPipeline(BasePipeline):
             os.symlink(os.path.abspath(args.resume), link)
         return saving_dir
 
+    def _setup_data_loader(self):
+        return None
+
+    def _setup_valid_data_loaders(self):
+        return []
+
     def _setup_config(self):
         pass
 
@@ -44,7 +50,7 @@ class TestingPipeline(BasePipeline):
         workers = []
         # Add a tester for each data loader
         for test_data_loader in self.test_data_loaders:
-            tester = Tester(self, test_data_loader, 0)
+            tester = Tester(pipeline=self, test_data_loader=test_data_loader)
             workers += [tester]
         return workers
 

--- a/src/pipeline/testing_pipeline.py
+++ b/src/pipeline/testing_pipeline.py
@@ -72,6 +72,7 @@ class TestingPipeline(BasePipeline):
         """
         for worker in self.workers:
             worker_output = worker.run(0)
-            self._save_inference_results(worker.data_loader.name, worker_output['saved'])
+            if not global_config.save_while_infer:
+                self._save_inference_results(worker.data_loader.name, worker_output['saved'])
             self.worker_outputs[worker.data_loader.name] = worker_output
         self._print_and_write_log(0, self.worker_outputs, write=False)

--- a/src/worker/tester.py
+++ b/src/worker/tester.py
@@ -66,12 +66,16 @@ class Tester(WorkerTemplate):
         if global_config.save_while_infer:
             # Save results
             name = self.data_loader.name
-            for i, output in enumerate(epoch_output['saved']['model_output']):
+
+            for i in range(len(epoch_output['saved']['model_output'])):
                 index = epoch_output['saved']['index'][i]
-                output_path = os.path.join(self.saving_dir, f'{name}_index{index:06d}.npy')
-                np.save(output_path, output)
+                output = {}
+                for saved_key in epoch_output['saved'].keys():
+                    output[saved_key] = epoch_output['saved'][saved_key][i]
+                output_path = os.path.join(self.saving_dir, f'{name}_index{index:06d}.npz')
+                np.savez(output_path, **output)
                 if index % 1000 == 0:
-                    logger.info(f'Saving output {output_path}...')
+                    logger.info(f'Saving output {output_path} ...')
 
         return epoch_output
 

--- a/src/worker/tester.py
+++ b/src/worker/tester.py
@@ -1,10 +1,14 @@
+import os
 import time
+import numpy as np
 
 import torch
 
 from .worker_template import WorkerTemplate
+from data_loader.base_data_loader import BaseDataLoader
 from pipeline.base_pipeline import BasePipeline
 from utils.global_config import global_config
+from utils.logging_config import logger
 
 
 class Tester(WorkerTemplate):
@@ -14,8 +18,10 @@ class Tester(WorkerTemplate):
     Note:
         Inherited from WorkerTemplate.
     """
-    def __init__(self, pipeline: BasePipeline, *args):
-        super().__init__(pipeline, *args)
+    def __init__(self, pipeline: BasePipeline, test_data_loader: BaseDataLoader):
+        super().__init__(pipeline=pipeline, data_loader=test_data_loader, step=0)
+        for attr_name in ['saving_dir']:
+            setattr(self, attr_name, getattr(pipeline, attr_name))
 
     @property
     def enable_grad(self):
@@ -40,9 +46,8 @@ class Tester(WorkerTemplate):
 
     def _update_output(self, epoch_output, products):
         """ Update the dictionary saver: extend entries """
-        data, model_output = products['data'], products['model_output']
 
-        def fetch_from_dict(dictionary):
+        def update_epoch_output_from_dict(dictionary):
             for key in dictionary.keys():
                 if key not in global_config.saved_keys:
                     continue
@@ -50,11 +55,30 @@ class Tester(WorkerTemplate):
                 saved_value = value.cpu().numpy() if torch.is_tensor(value) else value
                 epoch_output['saved'][key].extend([v for v in saved_value])
 
-        fetch_from_dict(data)
-        fetch_from_dict(model_output)
+        data, model_output = products['data'], products['model_output']
+        if global_config.save_while_infer:
+            # Clean previous results
+            epoch_output['saved'] = {k: [] for k in global_config.saved_keys}
+
+        for d in [data, model_output]:
+            update_epoch_output_from_dict(d)
+
+        if global_config.save_while_infer:
+            # Save results
+            name = self.data_loader.name
+            for i, output in enumerate(epoch_output['saved']['model_output']):
+                index = epoch_output['saved']['index'][i]
+                output_path = os.path.join(self.saving_dir, f'{name}_index{index:06d}.npy')
+                np.save(output_path, output)
+                if index % 1000 == 0:
+                    logger.info(f'Saving output {output_path}...')
+
         return epoch_output
 
     def _finalize_output(self, epoch_output):
         """ Return saved inference results along with log messages """
         log = {'elasped_time (s)': time.time() - epoch_output['epoch_start_time']}
         return {'saved': epoch_output['saved'], 'log': log}
+
+    def _print_log(self, epoch, batch_idx, batch_start_time, loss):
+        logger.info(f"Batch {batch_idx}, saving output ..")


### PR DESCRIPTION
## Why do we need this PR?
* To fix #61

## How is it implemented?
* Add save_while_infer option in template_test_config and update _update_output() in the tester to save results in each batch instead of putting everything in the epoch_output


#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
