### PR TITLE
Fix testing mode not using no_grad()

### DIFF
--- a/src/worker/tester.py
+++ b/src/worker/tester.py
@@ -28,7 +28,8 @@ class Tester(WorkerTemplate):
         return False
 
     def _run_and_optimize_model(self, data):
-        model_output = self.model(data)
+        with torch.no_grad():
+            model_output = self.model(data)
         return model_output, None
 
     def _setup_model(self):


### PR DESCRIPTION
## Why do we need this PR?
* Testing mode was not using no_grad(), which may cause potential problems

## How is it implemented?
* Add `with torch.no_grad():` in _run_and_optimize_model() in tester.py


#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
