### PR TITLE
Avoid dependency of imageio and Pytorch > 1.2

### DIFF
--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -8,9 +8,6 @@ from torchvision import transforms
 
 from utils.util import DeNormalize, lib_path, import_given_path
 
-inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
-fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
-
 
 class BaseMetric(torch.nn.Module):
     def __init__(self, output_key, target_key, nickname):
@@ -102,6 +99,7 @@ class FIDScoreOffline(BaseMetric):
         return None
 
     def finalize(self):
+        fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
         return fid_score.calculate_fid_given_paths(
             paths=[self.tmp_gt_dir.name, self.tmp_out_dir.name],
             batch_size=10, cuda=True, dims=2048)
@@ -152,12 +150,14 @@ class FIDScore(BaseMetric):
         m2 = np.mean(out_activations, axis=0)
         s1 = np.cov(gt_activations, rowvar=False)
         s2 = np.cov(out_activations, rowvar=False)
+        fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
         return fid_score.calculate_frechet_distance(m1, s1, m2, s2)
 
 
 class FIDScoreInceptionV3(FIDScore):
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
+        inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
         block_idx = inception.InceptionV3.BLOCK_INDEX_BY_DIM[2048]
         self._backbone = inception.InceptionV3([block_idx])
         self._backbone.eval()

--- a/src/model/metric.py
+++ b/src/model/metric.py
@@ -69,6 +69,7 @@ class FIDScoreOffline(BaseMetric):
     """
     Module calculating FID score by saving all images into temporary directories
     """
+    fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
@@ -99,8 +100,7 @@ class FIDScoreOffline(BaseMetric):
         return None
 
     def finalize(self):
-        fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
-        return fid_score.calculate_fid_given_paths(
+        return self.fid_score.calculate_fid_given_paths(
             paths=[self.tmp_gt_dir.name, self.tmp_out_dir.name],
             batch_size=10, cuda=True, dims=2048)
 
@@ -109,6 +109,7 @@ class FIDScore(BaseMetric):
     """
     Abstract class of FID score calculator (store inception activation in memory)
     """
+    fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
 
     def __init__(self, output_key, target_key, unnorm_mean=(0.5,), unnorm_std=(0.5,), nickname="FID_InceptionV3"):
         super().__init__(output_key, target_key, nickname)
@@ -150,16 +151,16 @@ class FIDScore(BaseMetric):
         m2 = np.mean(out_activations, axis=0)
         s1 = np.cov(gt_activations, rowvar=False)
         s2 = np.cov(out_activations, rowvar=False)
-        fid_score = import_given_path("fid_score", os.path.join(lib_path, 'pytorch_fid/fid_score.py'))
-        return fid_score.calculate_frechet_distance(m1, s1, m2, s2)
+        return self.fid_score.calculate_frechet_distance(m1, s1, m2, s2)
 
 
 class FIDScoreInceptionV3(FIDScore):
+    inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
+
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
-        inception = import_given_path("inception", os.path.join(lib_path, 'pytorch_fid/inception.py'))
-        block_idx = inception.InceptionV3.BLOCK_INDEX_BY_DIM[2048]
-        self._backbone = inception.InceptionV3([block_idx])
+        block_idx = self.inception.InceptionV3.BLOCK_INDEX_BY_DIM[2048]
+        self._backbone = self.inception.InceptionV3([block_idx])
         self._backbone.eval()
 
     def _get_activation(self, tensors):

--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -1,4 +1,8 @@
-from torch.utils.tensorboard import SummaryWriter
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    print("Using tensorboardX instead of built-in tensorboard (need PyTorch 1.2+ with Tensorboard 1.14+)")
+    from tensorboardX import SummaryWriter
 
 
 class WriterTensorboard():


### PR DESCRIPTION
## Why do we need this PR?
*  As a template, we should minimize the package dependency.
* Also fix #37 

## How is it implemented?
*  Since imageio and inception is only needed in the FID calculation,
 it will now only be used when imported.
* For Tensorboard summary writer, TensorboardX will be used when
 build-in Pytorch is not available.



#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
