### PR TITLE
Add assert for monitored_loader

### DIFF
--- a/src/pipeline/base_pipeline.py
+++ b/src/pipeline/base_pipeline.py
@@ -41,8 +41,8 @@ class BasePipeline(ABC):
         self._setup_writer()
         self.evaluation_metrics = self._setup_evaluation_metrics()
 
-        self._setup_config()
         self._setup_pipeline_specific_attributes()
+        self._setup_config()
 
         if args.resumed_checkpoint is not None:
             self._resume_checkpoint(args.resumed_checkpoint)

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -75,8 +75,11 @@ class TrainingPipeline(BasePipeline):
         self.monitored_loader = global_config['trainer']['monitored_loader']
         valid_loader_names = [loader.name for loader in self.valid_data_loaders]
         assert self.monitored_loader in valid_loader_names, \
-            f"Monitored loader '{self.monitored_loader}' not in validation data loaders {valid_loader_names}"
+            f"Config monitored loader '{self.monitored_loader}' is not in validation data loaders {valid_loader_names}"
         self.monitored_metric = global_config['trainer']['monitored_metric']
+        valid_metric_names = [f"avg_{metric.nickname}" for metric in self.evaluation_metrics] + ["avg_loss"]
+        assert self.monitored_metric in valid_metric_names, \
+            f"Config monitored metric '{self.monitored_metric}' is not in valid evaluation metrics {valid_metric_names}"
         self.monitor_mode = global_config['trainer']['monitor_mode']
         assert self.monitor_mode in ['min', 'max', 'off']
         self.monitor_best = math.inf if self.monitor_mode == 'min' else -math.inf

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -73,6 +73,9 @@ class TrainingPipeline(BasePipeline):
 
         # configuration to monitor model performance and save best
         self.monitored_loader = global_config['trainer']['monitored_loader']
+        valid_loader_names = [loader.name for loader in self.valid_data_loaders]
+        assert self.monitored_loader in valid_loader_names, \
+            f"Monitored loader '{self.monitored_loader}' not in validation data loaders {valid_loader_names}"
         self.monitored_metric = global_config['trainer']['monitored_metric']
         self.monitor_mode = global_config['trainer']['monitor_mode']
         assert self.monitor_mode in ['min', 'max', 'off']


### PR DESCRIPTION
## Why do we need this PR?
* If one forgets to change monitored_loader, no best_epoch will be recorded

## How is it implemented?
* Fetch validation dataloader names and check if monitored_loader is inside


#### PR readiness checklist
> - [x] Did it pass the Flake8 check?
> - [x] Did you test this PR?
